### PR TITLE
Add Vercel custom events

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,8 @@
     "@sanity/image-url": "^1.1.0",
     "react-intersection-observer": "^9.14.1",
     "@next/third-parties": "^15.1.4",
-    "@vercel/analytics": "^1.4.1"
+    "@vercel/analytics": "^1.4.1",
+    "@vercel/speed-insights": "^1.1.0"
   },
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { Personal } from "@/config";
 import { Analytics } from "@vercel/analytics/next";
 import CookieBanner from "@/components/common/CookieBanner";
 import { GoogleAnalytics } from "@next/third-parties/google";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 
 export const metadata: Metadata = {
   title: "CaiminRO | Portfolio",
@@ -30,6 +31,7 @@ export default function RootLayout({
         <Footer />
 
         <Analytics />
+        <SpeedInsights />
         {process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID && <CookieBanner />}
       </body>
     </html>

--- a/apps/web/src/components/common/Header.tsx
+++ b/apps/web/src/components/common/Header.tsx
@@ -1,8 +1,9 @@
 "use client";
+
 import { headerStyles } from "@/styles/components";
 import { Personal } from "@/config";
-import { GAUtil } from "@/utils/googleAnalytics";
 import Link from "next/link";
+import { AnalyticsUtil } from "@/utils";
 
 export default function Header() {
   const links = [
@@ -14,14 +15,19 @@ export default function Header() {
     <header className={headerStyles.header}>
       <nav className={headerStyles.navbar}>
         <div className={headerStyles.linkHome}>
-          <Link href="/">{Personal.FullName}</Link>
+          <Link
+            href="/"
+            onClick={() => AnalyticsUtil.buttonHeader("Homepage")}
+          >
+            {Personal.FullName}
+          </Link>
         </div>
 
         {links.map(([text, href], idx) => (
           <div key={idx} className={headerStyles.link} >
             <Link
               href={href as string}
-              onClick={() => GAUtil.sendEvent('button_Header', text)}
+              onClick={() => AnalyticsUtil.buttonHeader(text as string)}
             >
               {text}
             </Link>

--- a/apps/web/src/components/common/portfolio/PortfolioClient.tsx
+++ b/apps/web/src/components/common/portfolio/PortfolioClient.tsx
@@ -7,6 +7,7 @@ import PortfolioCard from "./PortfolioCard";
 import type { PortfolioItem, Skill } from "@/types";
 import DetailPanel from "@/components/common/portfolio/DetailPane";
 import { portfolioClientStyles } from "@/styles/components";
+import { AnalyticsUtil } from "@/utils";
 
 interface PortfolioSectionProps {
   items: PortfolioItem[];
@@ -56,6 +57,13 @@ export default function PortfolioClient({ items }: PortfolioSectionProps) {
       !selectedSkills.every((skill) => item.skills.some(t => t.name.includes(skill))));
   });
 
+  const handleCardOnClick = (item: PortfolioItem) => {
+    if (activeItem && activeItem.slug !== item.slug) {}
+      AnalyticsUtil.cardPortfolioItem(item.slug);
+
+    setActiveItem(item);
+  }
+
   return (
     <section
       ref={ref}
@@ -80,7 +88,7 @@ export default function PortfolioClient({ items }: PortfolioSectionProps) {
             {filteredItems.map((item, idx) => (
               <div
                 key={idx}
-                onClick={() => setActiveItem(item)}
+                onClick={() => handleCardOnClick(item)}
                 className="cursor-pointer"
               >
                 <PortfolioCard item={item} />

--- a/apps/web/src/components/sections/Hero.tsx
+++ b/apps/web/src/components/sections/Hero.tsx
@@ -1,9 +1,9 @@
 "use client";
+
 import { heroStyles } from "@/styles/components";
 import { Personal, Socials } from "@/config";
-
-import { GAUtil } from "@/utils/googleAnalytics";
 import Link from "next/link";
+import { AnalyticsUtil } from "@/utils";
 
 export default function Hero() {
   const jumps = [
@@ -28,7 +28,7 @@ export default function Hero() {
               key={idx}
               href={href as string}
               className={heroStyles.quickJump}
-              onClick={()=> GAUtil.sendEvent('button_Hero', text)}
+              onClick={()=> AnalyticsUtil.buttonHero(text as string)}
             >
               View {text}
             </Link>

--- a/apps/web/src/utils/analytics.ts
+++ b/apps/web/src/utils/analytics.ts
@@ -1,0 +1,30 @@
+import { GAUtil } from "@/utils/googleAnalytics";
+import { VAUtil } from "@/utils/vercelAnalytics";
+
+function buttonBase(eventName: string, buttonName: string) {
+  GAUtil.sendEvent(`button_${eventName}`, buttonName);
+  VAUtil.sendEvent(`button_${eventName}`, { buttonName });
+}
+
+function cardBase(eventName: string, cardName: string) {
+  GAUtil.sendEvent(`card_${eventName}`, cardName);
+  VAUtil.sendEvent(`card_${eventName}`, { cardName });
+}
+
+function buttonHeader(name: string) {
+  buttonBase('Header', name);
+}
+
+function buttonHero(name: string) {
+  buttonBase('Hero', name);
+}
+
+function cardPortfolioItem(name: string) {
+  cardBase('PortfolioItem', name);
+}
+
+export const AnalyticsUtil = {
+  buttonHeader,
+  buttonHero,
+  cardPortfolioItem
+};

--- a/apps/web/src/utils/googleAnalytics.ts
+++ b/apps/web/src/utils/googleAnalytics.ts
@@ -1,6 +1,8 @@
 import { sendGAEvent } from '@next/third-parties/google';
 
 function sendEvent(eventName: string, data: any) {
+  if (!process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID) return;
+
   sendGAEvent('event', eventName, { data });
 }
 

--- a/apps/web/src/utils/index.ts
+++ b/apps/web/src/utils/index.ts
@@ -7,3 +7,4 @@ export * from "./portfolio";
 export * from "./storage";
 export * from "./googleAnalytics";
 export * from "./vercelAnalytics";
+export * from "./analytics";

--- a/apps/web/src/utils/index.ts
+++ b/apps/web/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from "./formatDate";
 export * from "./portfolio";
 export * from "./storage";
 export * from "./googleAnalytics";
+export * from "./vercelAnalytics";

--- a/apps/web/src/utils/vercelAnalytics.ts
+++ b/apps/web/src/utils/vercelAnalytics.ts
@@ -1,0 +1,11 @@
+import { track } from "@vercel/analytics";
+
+function sendEvent(eventName: string, data: Record<string, any>) {
+  if (process.env.NEXT_PUBLIC_VERCEL_CUSTOM_EVENTS !== 'allowed') return;
+
+  track(eventName, data);
+}
+
+export const VAUtil = {
+  sendEvent
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@vercel/analytics':
         specifier: ^1.4.1
         version: 1.4.1(next@15.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      '@vercel/speed-insights':
+        specifier: ^1.1.0
+        version: 1.1.0(next@15.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       framer-motion:
         specifier: ^11.15.0
         version: 11.15.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2257,6 +2260,29 @@ packages:
     peerDependenciesMeta:
       '@remix-run/react':
         optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@1.1.0':
+    resolution: {integrity: sha512-rAXxuhhO4mlRGC9noa5F7HLMtGg8YF1zAN6Pjd1Ny4pII4cerhtwSG4vympbCl+pWkH7nBS9kVXRD4FAn54dlg==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
       next:
@@ -8790,6 +8816,11 @@ snapshots:
       - '@codemirror/search'
 
   '@vercel/analytics@1.4.1(next@15.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
+    optionalDependencies:
+      next: 15.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+
+  '@vercel/speed-insights@1.1.0(next@15.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
     optionalDependencies:
       next: 15.1.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0


### PR DESCRIPTION
Add custom event tracking for Vercel analytics. Also added Vercel speed analytics.

Now tracking Portolio Item card clicks, using the slug as the value sent through the event.